### PR TITLE
Allow to add parcel which is not available on default endpoint

### DIFF
--- a/custom_components/inpost_air/api.py
+++ b/custom_components/inpost_air/api.py
@@ -68,13 +68,16 @@ class InPostApi:
                 "Something really wrong happened!"
             ) from exception
 
-    async def _search_easypack24_locker(self, locker_code: str) -> InPostAirPoint | None:
+    async def _search_easypack24_locker(
+        self, locker_code: str
+    ) -> InPostAirPoint | None:
         """Find info about given parcel locker."""
         if not locker_code or locker_code == "":
             return None
 
         response = await self._request(
-            method="get", url="https://api-shipx-pl.easypack24.net/v1/points/" + locker_code
+            method="get",
+            url="https://api-shipx-pl.easypack24.net/v1/points/" + locker_code,
         )
         resp = await response.json()
 
@@ -101,13 +104,12 @@ class InPostApi:
             "o": resp_address.get("post_code") or "",
             "b": resp_address.get("building_number") or "",
             "h": resp.get("opening_hours") or "",
-            "i": "[]", # Unknown
+            "i": "[]",  # Unknown
             "l": {"a": location["latitude"], "o": location["longitude"]},
-            "p": 1 if resp.get("payment_type", {"0": ""}) == "0" else 0 ,
-            "s": 1, # Unkown - most lockers have 1 here
+            "p": 1 if resp.get("payment_type", {"0": ""}) == "0" else 0,
+            "s": 1,  # Unkown - most lockers have 1 here
         }
         return parcel_locker
-
 
     async def search_parcel_locker(self, locker_code: str) -> InPostAirPoint | None:
         """Find info about given parcel locker."""


### PR DESCRIPTION
Sometimes parcel is not added to [1] but it's available on [2]. 
It's possible to obtain data about parcel using [3] endpoint.

[1]https://inpost.pl/sites/default/files/points.json 
[2]https://inpost.pl/znajdz-paczkomat
[3]https://api-shipx-pl.easypack24.net/v1/points, API description can be found here https://dokumentacja-inpost.atlassian.net/wiki/spaces/PL/pages/28639230/%5B1.23.0%5D+Points

Feature can be checked by entering OLW05BAPP into "Parcel Locker ID" field.